### PR TITLE
Add support for ExternalRecorder channelscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ used for those disabled channels).
     specified name is arbitrary, and not used
     by the recorder itself.
 
-  * This program requires python3, and a number
+  * This program requires python3, and a number of
     libraries.  It is useful to run it standalone
     with the --help option before configuring it
     in MythTV to determine if you have the
@@ -110,11 +110,14 @@ used for those disabled channels).
   * Select "External (black box) recorder" as the card type
   * Specify the executable and (usually) append an arbritary unique device
     name, for example: /home/mythtv/bin/mythhdhrrecorder --devicename 0
-  * Specify the Max Recordings as 1
   * Select "Finish" to create the capture card
   * Repeat as needed for the number of tuners you want MythTV to utilize
-  * Perform video source setup as usual
-  * For each tuner, go to input connections and add the video source,
-    and select "Fetch Channels" if the video source is newly created
-    to populate the channel data (this does not work with ATSC video
-    sources due to the major/minor numbering, but workarounds exist)
+  * Select "Video sources" and create a video source
+  * Select "Input Connections"
+  * For each tuner:
+  *   Add the video source
+  *   In "Interactions between inputs"
+  *     Set "Max Recordings" to 1
+  *     Uncheck "Schedule as Group"
+  * Do "Scan for channels" for one tuner only (the video source is shared
+    with all tuners)

--- a/mythhdhrrecorder
+++ b/mythhdhrrecorder
@@ -902,7 +902,7 @@ class TransportStreamReaderThread(object):
         # that we can de-prioritize the legacy atsc1.0
         # channels on that device to try to reserve
         # the ATSC 3.0 capable tuners for ATSC 3.0
-        # content (this is a hueristic that may not
+        # content (this is a heuristic that may not
         # end up being right, but lets try it).
         ATSC3 = False
         for channel in lineup:

--- a/mythhdhrrecorder
+++ b/mythhdhrrecorder
@@ -868,6 +868,8 @@ class TransportStreamReaderThread(object):
         self._FIFO = FIFO
         self._interval = interval
         self._channels = dict()
+        self._channelList = list()
+        self._channelIndex = 0
         self._stream = None
         self._streaming_stop = 0
         self._streaming_stop_delay = .50
@@ -931,6 +933,8 @@ class TransportStreamReaderThread(object):
             else:
                 priority = 4
             self._channels[guidenumber].append({'Priority': priority, 'URL': channel['URL']})
+            # For channel scan by ExternalRecorder
+            self._channelList.append(channel)
 
     def start(self):
         with self._lock:
@@ -1176,6 +1180,24 @@ class TransportStreamReaderThread(object):
             else:
                 pass
 
+    def loadChannels(self):
+        return str(len(TSReader._channelList))
+
+    def firstChannel(self):
+        self._channelIndex = 0
+        return self.channelInfo()
+
+    def nextChannel(self):
+        self._channelIndex += 1
+        return self.channelInfo()
+
+    def channelInfo(self):
+        channel = self._channelList[self._channelIndex]
+        r = (channel['GuideNumber'] + ','       # For ATSC major-minor number
+            + channel['GuideName'] + ','        # For ATSC callsign
+            + channel['GuideName'] + ','        # Name
+            + str(channel['ProgramNumber']))    # XMLTVID
+        return r
 
 if __name__ == '__main__':
 
@@ -1338,6 +1360,16 @@ if __name__ == '__main__':
                 CommandResponse(serial, 'OK:Yes')
             else:
                 CommandResponse(serial, 'OK:No')
+        elif (cmd == 'LoadChannels'):
+            start = time.time()                # If needed, wait for for discovery to complete
+            while(((time.time() - start) < 10) and (HDHRBackgroundDiscoveryThread.is_alive())):
+                log(MythLog.RECORD, MythLog.DEBUG, 'Waiting for HDHR discovery to complete before processing LoadChannels')
+                time.sleep(.1)
+            CommandResponse(serial, 'OK:' + TSReader.loadChannels())
+        elif (cmd == 'FirstChannel'):
+            CommandResponse(serial, 'OK:' + TSReader.firstChannel())
+        elif (cmd == 'NextChannel'):
+            CommandResponse(serial, 'OK:' + TSReader.nextChannel())
         elif (cmd.startswith('TuneChannel:')):
             channel = cmd[12:]
             start = time.time()                # If needed, wait for for discovery to complete


### PR DESCRIPTION
Implemented the LoadChannels, FirstChannel and NextChannel commands of
the ExternalRecorder protocol so that the ExternalRecorder can do a channel scan.
The myththdhrrecorder did already read the channel lineup from the HDHomeRun but previously,
to get the channel information in MythTV it needed to be entered manually with mythtv-setup.
The code is tested with the HDHomeRun HDHR3-4DC for DVB-C and with the HDHR5-2DT for DVB-T2.
The ExternalRecorder asks for a callsign but there is no callsign available
in the channel lineup so the channel name is used here as well.
There will be some changes needed to support not only DVB but also ATSC because
of the major_minor channel number and the callsign.